### PR TITLE
Update preparing.R

### DIFF
--- a/R/preparing.R
+++ b/R/preparing.R
@@ -261,7 +261,7 @@ prepare_wgn <- function(meteo_lst, TMP_MAX = NULL, TMP_MIN = NULL, PCP = NULL, R
     wgn_mon$wet_dry <- aggregate(PCP~mon, df, my.pwd)[,2]
     wgn_mon$wet_wet <- aggregate(PCP~mon, df, my.pww)[,2]
     wgn_mon$slr_ave <- aggregate(SLR~mon, df, mean)[,2]
-    wgn_mon$dew_ave <- aggregate(RELHUM~mon, df, mean)[,2]/100
+    wgn_mon$dew_ave <- aggregate(RELHUM~mon, df, mean)[,2]
     wgn_mon$wnd_ave <- aggregate(WNDSPD~mon, df, mean)[,2]
     wgn_mon$wgn_id <- j
     ##Saving results


### PR DESCRIPTION
Removed conversion from percentage to fraction for relative humidity. Relative humidity input data should be already provided in fractions between 0-1 . This is why division by 100 is not necessary!